### PR TITLE
去除-Werror=format-security，使在GCC 4.9.1下编译通过

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -4,3 +4,7 @@
 #  Copyright (c) 2007. All rights reserved.
 require 'mkmf'
 create_makefile('gbarcode')
+# 避免gcc 4.9.1下的编译错误（也与mkmf生成的Makefile有关）
+makefile = File.open('Makefile').read
+makefile.gsub!('-Werror=format-security', '')
+File.open('Makefile', 'w').write makefile


### PR DESCRIPTION
```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /usr/bin/ruby2.1 extconf.rb
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
compiling svg.c
compiling codabar.c
compiling library.c
compiling barcode_wrap.c
compiling i25.c
compiling code39.c
compiling plessey.c
plessey.c: In function ‘Barcode_pls_encode’:
plessey.c:151:9: error: format not a string literal and no format arguments [-We
rror=format-security]
         sprintf(ptr, patterns[checkptr[strlen(text) * 4 + i]]);
         ^
cc1: some warnings being treated as errors
Makefile:224: recipe for target 'plessey.o' failed
make: *** [plessey.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/vagrant/.bundler/ruby/2.1.0/gbarcode-bf
84303b5e56 for inspection.
```

以上是Ruby 2.1.4 搭配 GCC 4.9.1 时的出错情况，sprintf函数要求第一个参数为字符串字面量，而不允许是字符指针。

在mkmf 生成的Makefile里去掉-Werror=format-security以忽视此警告。
